### PR TITLE
introduce a process-level lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 
 test:
 	go test -v github.com/pusher/buddha/tcptest
+	go test -v github.com/pusher/buddha/flock
 	go test -v github.com/pusher/buddha
 
 stage:

--- a/flock/lock.go
+++ b/flock/lock.go
@@ -1,0 +1,35 @@
+package flock
+
+import (
+	"os"
+)
+
+// Behaves like a *os.File but is only acquired with an exclusive flock().
+//
+// When the file is closed, the file is removed and the lock is released.
+type FileLock struct {
+	*os.File
+}
+
+// Either returns a flock-ed file or an error
+//
+// The lock is released by f.Close()-ing the file.
+func Open(path string) (f *FileLock, err error) {
+	var f2 *os.File
+	if f2, err = os.Create(path); err == nil {
+		if err = flock(f2); err != nil {
+			f2.Close()
+		} else {
+			f = &FileLock{f2}
+		}
+	}
+	return
+}
+
+func (f *FileLock) Close() (err error) {
+	if err = f.File.Close(); err == nil {
+		// Only remove the file if we actually held it before
+		err = os.Remove(f.File.Name())
+	}
+	return
+}

--- a/flock/lock_posix.go
+++ b/flock/lock_posix.go
@@ -1,0 +1,11 @@
+// +build linux darwin freebsd openbsd netbsd dragonfly solaris
+package flock
+
+import (
+	"os"
+	"syscall"
+)
+
+func flock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}

--- a/flock/lock_test.go
+++ b/flock/lock_test.go
@@ -1,0 +1,62 @@
+package flock
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLockIsLocking(t *testing.T) {
+	path := "test.lock"
+	l1, err := Open(path)
+	if err != nil {
+		t.Fatal("l1 error", err)
+	}
+	defer l1.Close()
+
+	// Test that the second lock cannot be acquired
+	l2, err := Open(path)
+	if l2 != nil {
+		t.Fatal("l2 expected to be nil")
+	}
+	if err == nil || err.Error() != "resource temporarily unavailable" {
+		t.Fatal("unexpected error", err)
+	}
+
+}
+
+func TestLockIsNotLeavingFilesAround(t *testing.T) {
+	path := "test.lock"
+	l1, err := Open(path)
+	if err != nil {
+		t.Fatal("l1 error", err)
+	}
+	err = l1.Close()
+	if err != nil {
+		t.Fatal("l1 close error", err)
+	}
+
+	// The file shouldn't exist after that
+	_, err = os.Stat(path)
+	if err == nil || err.Error() != "stat test.lock: no such file or directory" {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestLockIsWorkingWithUnacquiredFile(t *testing.T) {
+	path := "test.lock"
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Write([]byte("woot"))
+	f.Close()
+
+	l1, err := Open(path)
+	if err != nil {
+		t.Fatal("l1 error", err)
+	}
+	err = l1.Close()
+	if err != nil {
+		t.Fatal("l1 close error", err)
+	}
+}


### PR DESCRIPTION
Prevent multiple instances of buddha to run on the same machine at the same
time.

Since buddha is affecting the system services it's critical to understand it's
side-effects properly. The result of running multiple instances of buddha at
the same time is not well understood and might trigger some unexpected
race-conditions. The lock file prevents that.

/cc @jamescun 