### PR TITLE
Added --on-before-fail and --on-after-fail runtime options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_VERSION=0.3.1
+BUILD_VERSION=0.3.2
 BUILD_REVISION=$(shell git rev-parse HEAD)
 
 .PHONY: stage test build clean default

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Usage
   - `--on-before-fail`: determines the job behaviour on a before check failing.
     - `continue` continue with execution of the job
     - `skip` skip and start the next job (default)
-    - `end` end the current buddha run and exit
+    - `stop` end the current buddha run and exit
   - `--on-after-fail`: determines the run behavior on an after check failing.
     - `continue` continue with execution of next job
-    - `end` end the current buddha run and exit (default)
+    - `stop` end the current buddha run and exit (default)
 
 ```
 usage: buddha [flags] <jobs...>
@@ -99,8 +99,8 @@ flags:
   --config=<file>               manually specify job configuration file
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
-  --on-before-fail=skip         behaviour on before check failure (continue|skip|end)
-  --on-after-fail=end           behaviour on after check failure (continue|end)
+  --on-before-fail=skip         behaviour on before check failure (continue|skip|stop)
+  --on-after-fail=stop           behaviour on after check failure (continue|stop)
   --version                     display version information
 
 examples:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Below is an example of starting a redis server, ensuring is comes up with a TCP 
 Usage
 -----
 
+### Runtime Options
+
+  - `--on-before-fail`: determines the job behaviour on a before check failing.
+    - `continue` continue with execution of the job
+    - `skip` skip and start the next job (default)
+    - `end` end the current buddha run and exit
+  - `--on-after-fail`: determines the run behavior on an after check failing.
+    - `continue` continue with execution of next job
+    - `end` end the current buddha run and exit (default)
+
 ```
 usage: buddha [flags] <jobs...>
 
@@ -89,6 +99,8 @@ flags:
   --config=<file>               manually specify job configuration file
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
+  --on-before-fail=skip         behaviour on before check failure (continue|skip|end)
+  --on-after-fail=end           behaviour on after check failure (continue|end)
   --version                     display version information
 
 examples:

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -176,7 +176,7 @@ func runJob(job *buddha.Job) error {
 				log.Println(log.LevelFail, "warning: before checks failed, continuing anyway")
 				log.Println(log.LevelFail, "warning: %s", err)
 			} else {
-				log.Println(log.LevelFail, "error: before checks failed, skipping run")
+				log.Println(log.LevelFail, "error: before checks failed, skipping job")
 				log.Println(log.LevelFail, "error: %s", err)
 				continue
 			}
@@ -207,7 +207,7 @@ func runJob(job *buddha.Job) error {
 				continue
 			}
 
-			log.Println(log.LevelFail, "fatal: after checks failed")
+			log.Println(log.LevelFail, "fatal: after checks failed, ending run")
 			log.Println(log.LevelFail, "fatal: %s", err)
 			return err
 		}

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -26,7 +26,7 @@ var (
 	ConfigStdin  = flag.Bool("stdin", false, "")
 	LockPath     = flag.String("lock-path", filepath.Join(os.TempDir(), "buddha.lock"), "")
 	OnBeforeFail = flag.String("on-before-fail", "skip", "")
-	OnAfterFail  = flag.String("on-after-fail", "end", "")
+	OnAfterFail  = flag.String("on-after-fail", "stop", "")
 	ShowVersion  = flag.Bool("version", false, "")
 )
 
@@ -39,8 +39,8 @@ flags:
   --config=<file>               manually specify job configuration file
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
-  --on-before-fail=skip         job behaviour on before check failure (continue|skip|end)
-  --on-after-fail=end           run behaviour on after check failure (continue|end)
+  --on-before-fail=skip         job behaviour on before check failure (continue|skip|stop)
+  --on-after-fail=stop           run behaviour on after check failure (continue|stop)
   --version                     display version information
 
 examples:
@@ -169,7 +169,7 @@ func runJob(job *buddha.Job) error {
 		log.Println(log.LevelScnd, "Executing health checks")
 		err := executeChecks(cmd, cmd.Before)
 		if err != nil {
-			if *OnBeforeFail == "end" {
+			if *OnBeforeFail == "stop" {
 				log.Println(log.LevelFail, "fatal: before checks failed, ending run")
 				return err
 			} else if *OnBeforeFail == "continue" {

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -66,6 +66,19 @@ func init() {
 	flag.Usage = Usage
 	flag.Parse()
 
+	if *OnBeforeFail != "continue" &&
+		*OnBeforeFail != "skip" &&
+		*OnBeforeFail != "stop" {
+		fmt.Printf("'%s' is not a valid value for option --on-before-fail\r\n", *OnBeforeFail)
+		os.Exit(2)
+	}
+
+	if *OnAfterFail != "continue" &&
+		*OnAfterFail != "stop" {
+		fmt.Printf("'%s' is not a valid value for option --on-after-fail\r\n", *OnAfterFail)
+		os.Exit(2)
+	}
+
 	if *ShowVersion {
 		Version()
 		os.Exit(0)

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -58,8 +58,8 @@ examples:
 
 // --version
 func Version() {
-	fmt.Printf("Build Version: %s\r\n", BuildVersion)
-	fmt.Printf("Build Revision: %s\r\n", BuildRevision)
+	fmt.Println("Build Version:", BuildVersion)
+	fmt.Println("Build Revision:", BuildRevision)
 }
 
 func init() {
@@ -69,13 +69,13 @@ func init() {
 	if *OnBeforeFail != "continue" &&
 		*OnBeforeFail != "skip" &&
 		*OnBeforeFail != "stop" {
-		fmt.Printf("'%s' is not a valid value for option --on-before-fail\r\n", *OnBeforeFail)
+		fmt.Println(*OnBeforeFail, "is not a valid value for --on-before-fail")
 		os.Exit(2)
 	}
 
 	if *OnAfterFail != "continue" &&
 		*OnAfterFail != "stop" {
-		fmt.Printf("'%s' is not a valid value for option --on-after-fail\r\n", *OnAfterFail)
+		fmt.Println(*OnAfterFail, " is not a valid value for --on-after-fail")
 		os.Exit(2)
 	}
 

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -21,11 +21,13 @@ var (
 )
 
 var (
-	ConfigDir   = flag.String("config-dir", "/etc/buddha.d", "")
-	ConfigFile  = flag.String("config", "", "")
-	ConfigStdin = flag.Bool("stdin", false, "")
-	LockPath    = flag.String("lock-path", filepath.Join(os.TempDir(), "buddha.lock"), "")
-	ShowVersion = flag.Bool("version", false, "")
+	ConfigDir    = flag.String("config-dir", "/etc/buddha.d", "")
+	ConfigFile   = flag.String("config", "", "")
+	ConfigStdin  = flag.Bool("stdin", false, "")
+	LockPath     = flag.String("lock-path", filepath.Join(os.TempDir(), "buddha.lock"), "")
+	OnBeforeFail = flag.String("on-before-fail", "skip", "")
+	OnAfterFail  = flag.String("on-after-fail", "end", "")
+	ShowVersion  = flag.Bool("version", false, "")
 )
 
 // --help usage page
@@ -37,6 +39,8 @@ flags:
   --config=<file>               manually specify job configuration file
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
+  --on-before-fail=skip         job behaviour on before check failure (continue|skip|end)
+  --on-after-fail=end           run behaviour on after check failure (continue|end)
   --version                     display version information
 
 examples:
@@ -165,8 +169,17 @@ func runJob(job *buddha.Job) error {
 		log.Println(log.LevelScnd, "Executing health checks")
 		err := executeChecks(cmd, cmd.Before)
 		if err != nil {
-			log.Println(log.LevelFail, "error: before checks failed, skipping run")
-			continue
+			if *OnBeforeFail == "end" {
+				log.Println(log.LevelFail, "fatal: before checks failed, ending run")
+				return err
+			} else if *OnBeforeFail == "continue" {
+				log.Println(log.LevelFail, "warning: before checks failed, continuing anyway")
+				log.Println(log.LevelFail, "warning: %s", err)
+			} else {
+				log.Println(log.LevelFail, "error: before checks failed, skipping run")
+				log.Println(log.LevelFail, "error: %s", err)
+				continue
+			}
 		}
 
 		// execute command
@@ -188,9 +201,14 @@ func runJob(job *buddha.Job) error {
 		log.Println(log.LevelScnd, "Executing health checks")
 		err = executeChecks(cmd, cmd.After)
 		if err != nil {
+			if *OnAfterFail == "continue" {
+				log.Println(log.LevelFail, "warning: after checks failed, continuing anyway")
+				log.Println(log.LevelFail, "warning: %s", err)
+				continue
+			}
+
 			log.Println(log.LevelFail, "fatal: after checks failed")
 			log.Println(log.LevelFail, "fatal: %s", err)
-
 			return err
 		}
 	}


### PR DESCRIPTION
New runtime options:

  - `--on-before-fail`: determines the job behaviour on a before check failing.
    - `continue` continue with execution of the job
    - `skip` skip and start the next job (default)
    - `end` end the current buddha run and exit
  - `--on-after-fail`: determines the run behavior on an after check failing.
    - `continue` continue with execution of next job
    - `end` end the current buddha run and exit (default)