### PR TITLE
Execute before checks only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_VERSION=0.3.2
+BUILD_VERSION=0.3.3
 BUILD_REVISION=$(shell git rev-parse HEAD)
 
 .PHONY: stage test build clean default

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -175,7 +175,7 @@ func runJob(job *buddha.Job) error {
 	log.Println(log.LevelPrim, "Job: %s", job.Name)
 
 	for _, cmd := range job.Commands {
-		log.Println(log.LevelPrim, "Command: %s", job.Name)
+		log.Println(log.LevelPrim, "Command: %s", cmd.Name)
 
 		// execute before health checks
 		// these will only skip command, not terminate the run

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -40,7 +40,7 @@ flags:
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
   --on-before-fail=skip         job behaviour on before check failure (continue|skip|stop)
-  --on-after-fail=stop           run behaviour on after check failure (continue|stop)
+  --on-after-fail=stop          run behaviour on after check failure (continue|stop)
   --version                     display version information
 
 examples:
@@ -180,6 +180,8 @@ func runJob(job *buddha.Job) error {
 		// execute before health checks
 		// these will only skip command, not terminate the run
 		log.Println(log.LevelScnd, "Executing health checks")
+		failures := cmd.Failures
+		cmd.Failures = 1
 		err := executeChecks(cmd, cmd.Before)
 		if err != nil {
 			if *OnBeforeFail == "stop" {
@@ -194,6 +196,7 @@ func runJob(job *buddha.Job) error {
 				continue
 			}
 		}
+		cmd.Failures = failures
 
 		// execute command
 		log.Println(log.LevelScnd, "Executing Command: %s %s", cmd.Path, strings.Join(cmd.Args, " "))

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -178,7 +178,7 @@ func runJob(job *buddha.Job) error {
 		log.Println(log.LevelPrim, "Command: %s", cmd.Name)
 
 		// execute before health checks
-		// these will only skip command, not terminate the run
+		// these will execute once and depending on --on-before-file skip this job
 		log.Println(log.LevelScnd, "Executing health checks")
 		err := executeChecks(cmd, cmd.Before, 1)
 		if err != nil {


### PR DESCRIPTION
The purpose of before checks is for implementing idempotency, thus is makes little sense to execute them multiple time, particularly when used with `--on-before-fail`.

~~This implementation may not be the 100% cleanest but does stop the duplication of the `executeCheck` method or the adding of any more arguments to it (it already has > 3).~~