### PR TITLE
Remove absolute path to `true` command

### DIFF
--- a/check_exec_test.go
+++ b/check_exec_test.go
@@ -19,7 +19,7 @@ func TestCheckExecValidate(t *testing.T) {
 
 func TestCheckExecExecute(t *testing.T) {
 	c := CheckExec{
-		Path: "/bin/true",
+		Path: "true", // The `true` command
 	}
 
 	err := c.Execute(1 * time.Second)


### PR DESCRIPTION
@jamescun on my mac osx, it is in /usr/bin instead of /bin