### PR TITLE
Change behaviour on missing job

### DIFF
--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -147,7 +147,11 @@ func run(jobs buddha.Jobs) int {
 
 	// if not running all jobs, filter job list
 	if jobsToRun[0] != "all" {
-		jobs = jobs.Filter(jobsToRun)
+		var missing []string
+		jobs, missing = jobs.Select(jobsToRun)
+		if len(missing) > 0 {
+			log.Println(log.LevelInfo, "info: missing jobs %v", missing)
+		}
 	}
 
 	// perform sanity checks against jobs

--- a/job.go
+++ b/job.go
@@ -15,16 +15,26 @@ func (j Jobs) Len() int           { return len(j) }
 func (j Jobs) Swap(i, n int)      { j[i], j[n] = j[n], j[i] }
 func (j Jobs) Less(i, n int) bool { return j[i].Name < j[n].Name }
 
-// return new array of jobs matching name filter
-func (j Jobs) Filter(f []string) Jobs {
-	var n Jobs
-	for i := 0; i < len(j); i++ {
-		if inArray(f, j[i].Name) {
-			n = append(n, j[i])
+// Return:
+// * a new array of jobs matching name filter
+// * a list of names that wheren't found
+func (j Jobs) Select(f []string) (n Jobs, missing []string) {
+
+	for _, name := range f {
+		found := false
+		for _, job := range j {
+			if job.Name == name {
+				n = append(n, job)
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, name)
 		}
 	}
 
-	return n
+	return
 }
 
 type Job struct {

--- a/job_test.go
+++ b/job_test.go
@@ -5,29 +5,47 @@ import (
 	"testing"
 )
 
-func TestJobsFilter(t *testing.T) {
+func TestJobsSelect(t *testing.T) {
 	j := Jobs{&Job{Name: "foo"}, &Job{Name: "bar"}}
 
-	j = j.Filter([]string{"bar"})
+	j, missing := j.Select([]string{"bar"})
 
-	if len(j) != 1 {
+	if len(missing) > 0 {
+		t.Fatal("expected no job missing", missing)
+	} else if len(j) != 1 {
 		t.Fatal("expected 1 job, got", len(j))
 	} else if j[0].Name != "bar" {
 		t.Fatal("expected job[0] bar, got", j[0].Name)
 	}
 }
 
-func TestJobsFilterOrder(t *testing.T) {
+func TestJobsSelectOrder(t *testing.T) {
 	j := Jobs{&Job{Name: "foo"}, &Job{Name: "bar"}}
 
-	j = j.Filter([]string{"foo", "bar"})
+	j, missing := j.Select([]string{"foo", "bar"})
 
-	if len(j) != 2 {
+	if len(missing) > 0 {
+		t.Fatal("expected no job missing", missing)
+	} else if len(j) != 2 {
 		t.Fatal("expected 2 job, got", len(j))
 	} else if j[0].Name != "foo" {
 		t.Fatal("expected job[0] foo, got", j[0].Name)
 	} else if j[1].Name != "bar" {
 		t.Fatal("expected job[1] bar, got", j[1].Name)
+	}
+}
+
+func TestJobsSelectMissing(t *testing.T) {
+	j := Jobs{&Job{Name: "foo"}, &Job{Name: "bar"}}
+
+	j, missing := j.Select([]string{"foo", "something-else"})
+
+	if len(missing) != 1 {
+		t.Fatal("exected 1 missing job", j, missing)
+	} else if missing[0] != "something-else" {
+		t.Fatal("expected missing job to be 'something-else")
+	} else if len(j) != 1 {
+		t.Fatal("expected 1 job", j)
 	}
 }
 


### PR DESCRIPTION
Before this change running `buddha foobar` where foobar is not declared
in `/etc/buddha.d` would fail silently.