### PR TITLE
Split out "necessity checks" from "before checks"

### DIFF
--- a/check.go
+++ b/check.go
@@ -14,14 +14,14 @@ type Check interface {
 	Validate() error
 
 	// execute health check with timeout
-	// the error will be a CheckFailed if an expected possible failure case occurred
+	// the error will be a CheckFalse if an expected possible failure case occurred
 	// it will be some other error type for unexpected failures
 	Execute(time.Duration) error
 }
 
-type CheckFailed string
+type CheckFalse string
 
-func (e CheckFailed) Error() string {
+func (e CheckFalse) Error() string {
 	return string(e)
 }
 

--- a/check_exec.go
+++ b/check_exec.go
@@ -53,13 +53,13 @@ func (c CheckExec) Execute(timeout time.Duration) error {
 			if status, ok := processState.Sys().(syscall.WaitStatus); ok {
 				switch status.ExitStatus() {
 				case 1:
-					// The command failed in an expected way
-					fail <- CheckFailed("returned exit code 1")
+					// The check failed in an expected way
+					fail <- CheckFalse(fmt.Sprintf("command `%s` returned exit code 1", path))
 				case 2:
-					// The command failed with an unexpected error
-					fail <- fmt.Errorf("failed with exit code: 2")
+					// The command had an unexpected error
+					fail <- fmt.Errorf("command `%s` failed with exit code: 2", path)
 				default:
-					fail <- fmt.Errorf("unexpected exit code: %d", status.ExitStatus())
+					fail <- fmt.Errorf("command `%s` returned unexpected exit code: %d", path, status.ExitStatus())
 				}
 			} else {
 				fail <- fmt.Errorf("platform does not support exit codes")

--- a/check_exec_test.go
+++ b/check_exec_test.go
@@ -35,8 +35,8 @@ func TestCheckExecExecuteReturn1(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if _, ok := err.(CheckFailed); !ok {
-		t.Fatal("expected err to be CheckFailed")
+	if _, ok := err.(CheckFalse); !ok {
+		t.Fatal("expected err to be CheckFalse")
 	}
 }
 
@@ -47,8 +47,8 @@ func TestCheckExecExecuteReturn2(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if _, ok := err.(CheckFailed); ok {
-		t.Fatal("expected err to not be CheckFailed")
+	if _, ok := err.(CheckFalse); ok {
+		t.Fatal("expected err to not be CheckFalse")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestCheckExecExecuteTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if _, ok := err.(CheckFailed); ok {
-		t.Fatal("expected err to not be CheckFailed")
+	if _, ok := err.(CheckFalse); ok {
+		t.Fatal("expected err to not be CheckFalse")
 	}
 }

--- a/check_http.go
+++ b/check_http.go
@@ -46,12 +46,12 @@ func (c CheckHTTP) Execute(timeout time.Duration) error {
 
 	res, err := client.Do(req)
 	if err != nil {
-		return CheckFailed(fmt.Sprintf("HTTP request failed: %s", err))
+		return CheckFalse(fmt.Sprintf("HTTP request failed: %s", err))
 	}
 	defer res.Body.Close()
 
 	if !c.checkStatusCode(res.StatusCode) {
-		return CheckFailed(fmt.Sprintf("Unacceptable status code %d", res.StatusCode))
+		return CheckFalse(fmt.Sprintf("Unacceptable status code %d", res.StatusCode))
 	}
 
 	return nil

--- a/check_tcp.go
+++ b/check_tcp.go
@@ -29,7 +29,7 @@ func (c CheckTCP) Execute(timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", c.Addr, timeout)
 	if err != nil {
 		log.Println(log.LevelInfo, "TCP connection failed: %s", err)
-		return CheckFailed(fmt.Sprintf("TCP connection failed: %s", err))
+		return CheckFalse(fmt.Sprintf("TCP connection failed: %s", err))
 	}
 	defer conn.Close()
 

--- a/cmd/buddha.go
+++ b/cmd/buddha.go
@@ -21,13 +21,14 @@ var (
 )
 
 var (
-	ConfigDir    = flag.String("config-dir", "/etc/buddha.d", "")
-	ConfigFile   = flag.String("config", "", "")
-	ConfigStdin  = flag.Bool("stdin", false, "")
-	LockPath     = flag.String("lock-path", filepath.Join(os.TempDir(), "buddha.lock"), "")
-	OnBeforeFail = flag.String("on-before-fail", "skip", "")
-	OnAfterFail  = flag.String("on-after-fail", "stop", "")
-	ShowVersion  = flag.Bool("version", false, "")
+	ConfigDir     = flag.String("config-dir", "/etc/buddha.d", "")
+	ConfigFile    = flag.String("config", "", "")
+	ConfigStdin   = flag.Bool("stdin", false, "")
+	LockPath      = flag.String("lock-path", filepath.Join(os.TempDir(), "buddha.lock"), "")
+	OnUnnecessary = flag.String("on-unnecessary", "skip", "")
+	OnBeforeFail  = flag.String("on-before-fail", "skip", "")
+	OnAfterFail   = flag.String("on-after-fail", "stop", "")
+	ShowVersion   = flag.Bool("version", false, "")
 )
 
 // --help usage page
@@ -39,6 +40,7 @@ flags:
   --config=<file>               manually specify job configuration file
   --stdin                       accept job configuration from STDIN
   --lock-path=/tmp/buddha.lock  path to lock file
+  --on-unnecessary=skip         job behaviour if necessity checks deem it unnecessary (continue|skip)
   --on-before-fail=skip         job behaviour on before check failure (continue|skip|stop)
   --on-after-fail=stop          run behaviour on after check failure (continue|stop)
   --version                     display version information
@@ -176,22 +178,37 @@ func runJob(job *buddha.Job) error {
 	for _, cmd := range job.Commands {
 		log.Println(log.LevelPrim, "Command: %s", cmd.Name)
 
+		log.Println(log.LevelScnd, "Executing necessity checks")
+		isNecessaryResults, err := executeChecks(cmd, cmd.Necessity, executeNecessityCheck)
+		if err != nil {
+			log.Println(log.LevelFail, "fatal: unexpected error from necessity check, ending run")
+			return err
+		}
+		if allFalse(isNecessaryResults) {
+			if *OnUnnecessary == "continue" {
+				log.Println(log.LevelFail, "warning: job unnecessary, continuing anyway")
+			} else {
+				log.Println(log.LevelInfo, "Job deemed unnecessary, skipping")
+				continue
+			}
+		}
+
 		// execute before health checks
 		// these will execute once and depending on --on-before-fail skip this job
 		log.Println(log.LevelScnd, "Executing before checks")
-		result, err := executeChecks(cmd, cmd.Before, 1)
+		checksResults, err := executeChecks(cmd, cmd.Before, executeHealthCheck)
 		if err != nil {
-			log.Println(log.LevelFail, "fatal: before checks failed, ending run")
+			log.Println(log.LevelFail, "fatal: unexpected error from before check, ending run")
 			return err
 		}
-		if !result {
+		if anyFalse(checksResults) {
 			if *OnBeforeFail == "stop" {
-				log.Println(log.LevelFail, "fatal: before checks returned false, ending run")
+				log.Println(log.LevelFail, "fatal: before returned false, ending run")
 				return nil
 			} else if *OnBeforeFail == "continue" {
-				log.Println(log.LevelFail, "warning: before checks returned false, continuing anyway")
+				log.Println(log.LevelFail, "warning: before returned false, continuing anyway")
 			} else {
-				log.Println(log.LevelInfo, "Before checks returned false, skipping job")
+				log.Println(log.LevelFail, "warning: before returned false, skipping job")
 				continue
 			}
 		}
@@ -211,18 +228,18 @@ func runJob(job *buddha.Job) error {
 
 		// execute after health checks
 		log.Println(log.LevelScnd, "Executing after checks")
-		result, err = executeChecks(cmd, cmd.After, cmd.Failures)
+		checksResults, err = executeChecks(cmd, cmd.After, executeHealthCheck)
 		if err != nil {
-			log.Println(log.LevelFail, "fatal: after checks failed, ending run. err: %s", err)
+			log.Println(log.LevelFail, "fatal: unexpected error from after check, ending run. err: %s", err)
 			return err
 		}
-		if !result {
+		if anyFalse(checksResults) {
 			if *OnAfterFail == "continue" {
-				log.Println(log.LevelFail, "warning: after checks returned false, continuing anyway")
+				log.Println(log.LevelFail, "warning: after checks failed, continuing anyway")
 				continue
 			}
 
-			log.Println(log.LevelFail, "fatal: after checks returned false, ending run")
+			log.Println(log.LevelFail, "fatal: after checks failed, ending run")
 			return err
 		}
 	}
@@ -236,9 +253,9 @@ func execStdout(line string) {
 }
 
 // execute independent checks in worker goroutines
-func executeChecks(cmd buddha.Command, checks buddha.Checks, failures int) (bool, error) {
+func executeChecks(cmd buddha.Command, checks buddha.Checks, executeCheck ExecuteCheck) ([]bool, error) {
 	if len(checks) == 0 {
-		return true, nil
+		return nil, nil
 	}
 
 	wg := new(sync.WaitGroup)
@@ -248,37 +265,60 @@ func executeChecks(cmd buddha.Command, checks buddha.Checks, failures int) (bool
 	for _, check := range checks {
 		wg.Add(1)
 
-		go executeCheck(wg, cmd, check, done, fail, failures)
+		go executeCheck(wg, cmd, check, done, fail)
 	}
 	wg.Wait()
 	close(done)
 
 	select {
 	case err := <-fail:
-		return false, err
+		return nil, err
 	default:
-		// Only return true if all checks returned true
-		aggregatedResult := true
+		results := make([]bool, len(checks))
+		i := 0
 		for result := range done {
-			aggregatedResult = aggregatedResult && result
+			results[i] = result
+			i++
 		}
-		return aggregatedResult, nil
+		return results, nil
+	}
+}
+
+type ExecuteCheck func(*sync.WaitGroup, buddha.Command, buddha.Check, chan bool, chan error)
+
+func executeNecessityCheck(wg *sync.WaitGroup, cmd buddha.Command, check buddha.Check, done chan bool, fail chan error) {
+	defer wg.Done()
+
+	log.Println(log.LevelInfo, "Check %s: checking...", check.String())
+	err := check.Execute(cmd.Timeout.Duration())
+	if err != nil {
+		switch e := err.(type) {
+		case buddha.CheckFalse:
+			log.Println(log.LevelInfo, "Check %s: deemed job unnecessary: %s", check.String(), e)
+			done <- false
+		default:
+			// unexpected failure
+			fail <- err
+		}
+	} else {
+		log.Println(log.LevelInfo, "Check %s: deemed job necessary", check.String())
+		done <- true
 	}
 }
 
 // execute a check synchronously as defined by check settings as part of a worker waitgroup
-func executeCheck(wg *sync.WaitGroup, cmd buddha.Command, check buddha.Check, done chan bool, fail chan error, failures int) {
+func executeHealthCheck(wg *sync.WaitGroup, cmd buddha.Command, check buddha.Check, done chan bool, fail chan error) {
 	defer wg.Done()
 
-	for i := 1; i <= failures; i++ {
-		log.Println(log.LevelInfo, "Check %d/%d: %s: checking...", i, failures, check.String())
+	for i := 1; i <= cmd.Failures; i++ {
+		log.Println(log.LevelInfo, "Check %d/%d: %s: checking...", i, cmd.Failures, check.String())
 		err := check.Execute(cmd.Timeout.Duration())
 		if err != nil {
 			switch e := err.(type) {
-			case buddha.CheckFailed:
-				log.Println(log.LevelInfo, "Check %d/%d: %s: failed with: %s", i, failures, check.String(), e)
-				if i < failures {
-					log.Println(log.LevelInfo, "Check %d/%d: %s: waiting %s...", i, failures, check.String(), cmd.Interval)
+			case buddha.CheckFalse:
+				log.Println(log.LevelInfo, "Check %d/%d: %s: returned false: %s", i, cmd.Failures, check.String(), e)
+				if i < cmd.Failures {
+					log.Println(log.LevelInfo, "Check %d/%d: %s: waiting %s...", i, cmd.Failures, check.String(), cmd.Interval)
 					time.Sleep(cmd.Interval.Duration())
 				}
 			default:
@@ -287,11 +327,27 @@ func executeCheck(wg *sync.WaitGroup, cmd buddha.Command, check buddha.Check, do
 				return
 			}
 		} else {
-			log.Println(log.LevelInfo, "Check %d/%d: %s success!", i, failures, check.String())
+			log.Println(log.LevelInfo, "Check %d/%d: %s success!", i, cmd.Failures, check.String())
 			done <- true
 			return
 		}
 	}
-	log.Println(log.LevelInfo, "All attempts returned false")
 	done <- false
+}
+
+func allFalse(arr []bool) bool {
+	aggregate := true
+	for _, v := range arr {
+		aggregate = aggregate && !v
+	}
+	return aggregate
+}
+
+func anyFalse(arr []bool) bool {
+	for _, v := range arr {
+		if v == false {
+			return true
+		}
+	}
+	return false
 }

--- a/command.go
+++ b/command.go
@@ -16,8 +16,9 @@ type Command struct {
 	// arguments to pass to executable
 	Args []string `json:"args,omitempty"`
 
-	Before Checks `json:"before"`
-	After  Checks `json:"after"`
+	Necessity Checks `json:"necessity"`
+	Before    Checks `json:"before"`
+	After     Checks `json:"after"`
 
 	// timeout between executing command and beginning health checking
 	Grace Duration `json:"grace"`


### PR DESCRIPTION
That way false returned results can be handled differently:

- Necessity checks do not need to retry
- All necessity checks return false if all checks return false
  whereas healthchecks return false if any checks return false

Also switched form using terminology of check "failures" to checks
returning "false results"